### PR TITLE
Update repository URL after moving out of monorepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "tsc -b",
     "test": "jest"
   },
-  "repository": "https://github.com/nteract/nteract/tree/master/packages/mathjax",
+  "repository": "https://github.com/nteract/mathjax",
   "keywords": [
     "mathjax"
   ],


### PR DESCRIPTION
Updates the package json `repository` field to point to this repo instead of the `nteract/nteract` monorepo, fixing the link on https://www.npmjs.com/package/@nteract/mathjax.