### PR TITLE
Fix package title on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @nteract/actions
+# @nteract/mathjax
 
 This package contains two main components, `<MathJax.Context>` and `<MathJax.Node>`. The `<MathJax.Context>` component loads MathJax and makes it available to children elements via the React Context API. `<MathJax.Node>` takes raw text for rendering and uses MathJax to render formatted math.
 


### PR DESCRIPTION
Seems like it was a copy/paste error when migrating from the monorepo