### PR TITLE
Fixing mathjax cdn url and update tests/snapshots

### DIFF
--- a/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/__tests__/__snapshots__/index.spec.tsx.snap
@@ -14,7 +14,7 @@ exports[`MathJax Node can be renderered without provider 1`] = `
     onError={[Function]}
     onLoad={null}
     options={Object {}}
-    src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML"
+    src="https://cdn.jsdelivr.net/npm/mathjax@2.7.8/MathJax.js?config=TeX-MML-AM_CHTML"
   >
     <MathJaxNode
       inline={false}
@@ -60,7 +60,7 @@ exports[`MathJax Text node renders LaTeX text 1`] = `
     onError={[Function]}
     onLoad={null}
     options={Object {}}
-    src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML"
+    src="https://cdn.jsdelivr.net/npm/mathjax@2.7.8/MathJax.js?config=TeX-MML-AM_CHTML"
   >
     <MathJaxText
       onRender={null}

--- a/__tests__/index.spec.tsx
+++ b/__tests__/index.spec.tsx
@@ -7,7 +7,7 @@ import loadScript from "load-script";
 import { Node, Provider, Text } from "../src";
 
 const mathJaxUrl =
-  "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.8/MathJax.js?config=TeX-MML-AM_CHTML";
+  "https://cdn.jsdelivr.net/npm/mathjax@2.7.8/MathJax.js?config=TeX-MML-AM_CHTML";
 
 describe("MathJax", () => {
   test("Node can be renderered without provider", () => {

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -27,7 +27,7 @@ type State = MathJaxContextValue;
 export default class Provider extends React.Component<Props, State> {
   static defaultProps = {
     src:
-      "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.8/MathJax.js?config=TeX-MML-AM_CHTML",
+      "https://cdn.jsdelivr.net/npm/mathjax@2.7.8/MathJax.js?config=TeX-MML-AM_CHTML",
     input: "tex",
     didFinishTypeset: null,
     delay: 0,


### PR DESCRIPTION
The last CDN url update caused a 404 on all libraries that depend on this one. Fixing it as suggested in issue [#5](https://github.com/nteract/mathjax/issues/5)

@captainsafia 