### PR TITLE
Upgrading MathJax version 2.7.8 to 2.7.9

### DIFF
--- a/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/__tests__/__snapshots__/index.spec.tsx.snap
@@ -14,7 +14,7 @@ exports[`MathJax Node can be renderered without provider 1`] = `
     onError={[Function]}
     onLoad={null}
     options={Object {}}
-    src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.1.0/es5/tex-chtml-full.min.js"
+    src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-MML-AM_CHTML"
   >
     <MathJaxNode
       inline={false}

--- a/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/__tests__/__snapshots__/index.spec.tsx.snap
@@ -14,7 +14,7 @@ exports[`MathJax Node can be renderered without provider 1`] = `
     onError={[Function]}
     onLoad={null}
     options={Object {}}
-    src="https://cdn.jsdelivr.net/npm/mathjax@2.7.8/MathJax.js?config=TeX-MML-AM_CHTML"
+    src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.1.0/es5/tex-chtml-full.min.js"
   >
     <MathJaxNode
       inline={false}
@@ -60,7 +60,7 @@ exports[`MathJax Text node renders LaTeX text 1`] = `
     onError={[Function]}
     onLoad={null}
     options={Object {}}
-    src="https://cdn.jsdelivr.net/npm/mathjax@2.7.8/MathJax.js?config=TeX-MML-AM_CHTML"
+    src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.1.0/es5/tex-chtml-full.min.js"
   >
     <MathJaxText
       onRender={null}

--- a/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/__tests__/__snapshots__/index.spec.tsx.snap
@@ -60,7 +60,7 @@ exports[`MathJax Text node renders LaTeX text 1`] = `
     onError={[Function]}
     onLoad={null}
     options={Object {}}
-    src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.1.0/es5/tex-chtml-full.min.js"
+    src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-MML-AM_CHTML"
   >
     <MathJaxText
       onRender={null}

--- a/__tests__/index.spec.tsx
+++ b/__tests__/index.spec.tsx
@@ -6,8 +6,7 @@ jest.mock("load-script");
 import loadScript from "load-script";
 import { Node, Provider, Text } from "../src";
 
-const mathJaxUrl =
-  "https://cdn.jsdelivr.net/npm/mathjax@2.7.8/MathJax.js?config=TeX-MML-AM_CHTML";
+const mathJaxUrl = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.1.0/es5/tex-chtml-full.min.js";
 
 describe("MathJax", () => {
   test("Node can be renderered without provider", () => {

--- a/__tests__/index.spec.tsx
+++ b/__tests__/index.spec.tsx
@@ -6,7 +6,7 @@ jest.mock("load-script");
 import loadScript from "load-script";
 import { Node, Provider, Text } from "../src";
 
-const mathJaxUrl = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.1.0/es5/tex-chtml-full.min.js";
+const mathJaxUrl = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-MML-AM_CHTML";
 
 describe("MathJax", () => {
   test("Node can be renderered without provider", () => {

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -27,7 +27,7 @@ type State = MathJaxContextValue;
 export default class Provider extends React.Component<Props, State> {
   static defaultProps = {
     src:
-      "https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.1.0/es5/tex-chtml-full.min.js",
+      "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-MML-AM_CHTML",
     input: "tex",
     didFinishTypeset: null,
     delay: 0,

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -27,7 +27,7 @@ type State = MathJaxContextValue;
 export default class Provider extends React.Component<Props, State> {
   static defaultProps = {
     src:
-      "https://cdn.jsdelivr.net/npm/mathjax@2.7.8/MathJax.js?config=TeX-MML-AM_CHTML",
+      "https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.1.0/es5/tex-chtml-full.min.js",
     input: "tex",
     didFinishTypeset: null,
     delay: 0,


### PR DESCRIPTION
Closes #8

Updating to the next version of MathJax.